### PR TITLE
fix: state variable is now quoted and surrounded with two brackets.

### DIFF
--- a/changelogs/fragments/3-quote-state-variable.yml
+++ b/changelogs/fragments/3-quote-state-variable.yml
@@ -1,0 +1,3 @@
+release_summary: Fix package installation issues with custom state values.
+bugfixes:
+  - deps_mgr - Quoted and bracketed the "state" variable.  This prevents unexpected failures due to custom states.

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -5,7 +5,7 @@
 
 namespace: "marshallwp"
 name: "general"
-version: 1.0.1
+version: 1.0.2
 readme: README.md
 authors:
   - William P. Marshall

--- a/roles/deps_mgr/tasks/packages.yml
+++ b/roles/deps_mgr/tasks/packages.yml
@@ -30,7 +30,7 @@
       }}"
   ansible.builtin.package:
     name: "{{ package_list | selectattr('state', 'equalto', state) | map(attribute='name') }}"
-    state: state
+    state: "{{ state }}"
   loop: "{{ package_list | map(attribute='state') | ansible.builtin.unique }}"
   loop_control:
     loop_var: state


### PR DESCRIPTION
This typo caused package installation to unexpectedly fail.