### PR TITLE
feat(deps_mgr): allow for list merge method to be specified.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,25 @@ Marshallwp General Collection Release Notes
 
 .. contents:: Topics
 
+v1.0.2
+======
+
+Release Summary
+---------------
+
+Fix package installation issues with custom state values and add allow the user to specify how different levels of the deps_mgr_list are merged.
+
+Minor Changes
+-------------
+
+- deps_mgr - You can now specify whether to use the `lowest_only` or `precision` merge methods for packages and repositories.
+
+Bugfixes
+--------
+
+- deps_mgr - Quoted and bracketed the "state" variable.  This prevents unexpected failures due to custom states.
+- deps_mgr - Quoted the name of the 'Make Packages' task in packages.yml.
+
 v1.0.1
 ======
 

--- a/changelogs/.plugin-cache.yaml
+++ b/changelogs/.plugin-cache.yaml
@@ -8,7 +8,7 @@ plugins:
   connection: {}
   filter:
     generate_paths:
-      description: flattens a nested directory tree of directory names into a list
+      description: Flattens a nested directory tree of directory names into a list
         of paths.
       name: generate_paths
       version_added: 1.0.0
@@ -25,4 +25,4 @@ plugins:
   strategy: {}
   test: {}
   vars: {}
-version: 1.0.1
+version: 1.0.2

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -5,17 +5,34 @@ releases:
   1.0.1:
     changes:
       bugfixes:
-        - 'Plugins - All output strings are now run through the included to_text function
-          to ensure proper encoding.
+      - 'Plugins - All output strings are now run through the included to_text function
+        to ensure proper encoding.
 
-          See: https://docs.ansible.com/ansible/latest/dev_guide/developing_plugins.html#string-encoding'
+        See: https://docs.ansible.com/ansible/latest/dev_guide/developing_plugins.html#string-encoding'
       doc_changes:
-        - LICENSE - corrected licensing to match reality.
-        - Plugins - Added documentation to all plugins.
-        - READMEs - Added parameter definitions, expanded on dependency usage, and eliminated
-          leftover templating cruft.
+      - LICENSE - corrected licensing to match reality.
+      - Plugins - Added documentation to all plugins.
+      - READMEs - Added parameter definitions, expanded on dependency usage, and eliminated
+        leftover templating cruft.
       release_summary: Update documentation collection-wide and make minor bugfixes
         to plugins.
     fragments:
-      - 2-correct-documentation.yml
+    - 2-correct-documentation.yml
     release_date: '2024-10-24'
+  1.0.2:
+    changes:
+      bugfixes:
+      - deps_mgr - Quoted and bracketed the "state" variable.  This prevents unexpected
+        failures due to custom states.
+      - deps_mgr - Quoted the name of the 'Make Packages' task in packages.yml so the state variable value is included.
+      minor_changes:
+      - deps_mgr - You can now specify whether to use the `lowest_only` or `precision`
+        merge methods for packages and repositories.
+      release_summary: Fix package installation issues with custom state values and
+        add allow the user to specify how different levels of the deps_mgr_list are
+        merged.
+    fragments:
+    - 3-quote-state-variable.yml
+    - 4-quote-make-packages-name.yml
+    - 6-merge-method.yml
+    release_date: '2024-10-28'

--- a/changelogs/fragments/3-quote-state-variable.yml
+++ b/changelogs/fragments/3-quote-state-variable.yml
@@ -1,3 +1,0 @@
-release_summary: Fix package installation issues with custom state values.
-bugfixes:
-  - deps_mgr - Quoted and bracketed the "state" variable.  This prevents unexpected failures due to custom states.

--- a/changelogs/fragments/4-quote-make-packages-name.yml
+++ b/changelogs/fragments/4-quote-make-packages-name.yml
@@ -1,3 +1,0 @@
-release_summary: Quote the name of the packages task to ensure the value of the 'state' variable is used.
-bugfixes:
-  - deps_mgr - Quoted the name of the 'Make Packages' task in packages.yml.

--- a/changelogs/fragments/6-merge-method.yml
+++ b/changelogs/fragments/6-merge-method.yml
@@ -1,0 +1,3 @@
+release_summary: Allow the user to specify how different levels of the deps_mgr_list are merged.
+minor_changes:
+  - deps_mgr - You can now specify whether to use the `lowest_only` or `precision` merge methods for packages and repositories.

--- a/changelogs/fragments/6-merge-method.yml
+++ b/changelogs/fragments/6-merge-method.yml
@@ -1,3 +1,0 @@
-release_summary: Allow the user to specify how different levels of the deps_mgr_list are merged.
-minor_changes:
-  - deps_mgr - You can now specify whether to use the `lowest_only` or `precision` merge methods for packages and repositories.

--- a/roles/deps_mgr/README.md
+++ b/roles/deps_mgr/README.md
@@ -24,16 +24,27 @@ Requires the `community.general` collection for DNF Config, Homebrew, Pkg5, and 
 Role Variables
 --------------
 
-| Name | Alias | Description |
-| ---- | ----- | ----------- |
+| Name | Alias | Description | Default |
+| ---- | ----- | ----------- | ------- |
+| deps_mgr_package_merge_method | | Merge method to use when choosing what packages to manage and how. | precedence |
+| deps_mgr_repo_merge_method | | Merge method to use when choosing what repositories to manage and how. | lowest_only |
 | deps_mgr_list | dependencies | Hierarchical dictionary of packages and repositories to be configured at the os family, distribution, and major version levels. |
+
+### Merge Methods
+If you have packages or repositories specified at multiple levels of the `deps_mgr_list`, the merge method determines how ansible chooses entries to use.  It is set for packages and repositories via the `deps_mgr_package_merge_method` and `deps_mgr_repo_merge_method` variables respectively. Currently we support the following methods:
+
+| Method | Description |
+| ------ | ----------- |
+| lowest_only | The simplest method, it gets items from the most precise matching list and ignores all the others. |
+| precision | Combine lists with precidence ordered from most precise to least. Higher-level items will be included, but can be overridden by lower level ones. |
+
 
 Dependencies
 ------------
 
 <!-- A list of other roles hosted on Galaxy should go here, plus any details in regards to parameters that may need to be set for other roles, or variables that are used from other roles. -->
 
-community.general
+`community.general`
 
 Example Playbook
 ----------------

--- a/roles/deps_mgr/defaults/main.yml
+++ b/roles/deps_mgr/defaults/main.yml
@@ -1,4 +1,10 @@
 ---
+# List merge method can be either
+# precedence - Combine lists with precidence ordered from most precise to least. Higher-level items will be included, but can be overridden by lower level ones.
+# lowest_only - The simplest method, it gets items from the most precise matching list and ignores all the others.
+deps_mgr_package_merge_method: precedence
+deps_mgr_repo_merge_method: lowest_only
+
 deps_mgr_list: "{{ dependencies }}"
 # Example for Installing Postgres 16 with packages required for configuration via community.general.postgres.
 # deps_mgr_list:

--- a/roles/deps_mgr/tasks/main.yml
+++ b/roles/deps_mgr/tasks/main.yml
@@ -1,13 +1,22 @@
 ---
 - name: Install Required Repositories
   vars:
+    # Get Repositories at different levels
     os_repo_setup: "{{ deps_mgr_list[ansible_facts['os_family']] }}"
     dist_repo_setup: "{{ os_repo_setup[ansible_facts['distribution']] }}"
     maj_ver_repo_setup: "{{ dist_repo_setup[ansible_facts['distribution_major_version']] }}"
-  loop: "{{ maj_ver_repo_setup['repositories'] |
-            default(dist_repo_setup['repositories']) |
-            default(os_repo_setup['repositories']) |
-            default([]) }}"
+    # *Merge through various methods
+    # Only get repositories from the lowest-level that lists them.
+    lowest_only_merge: "{{ maj_ver_repo_setup['repositories'] |
+                          default(dist_repo_setup['repositories']) |
+                          default(os_repo_setup['repositories']) |
+                          default([]) }}"
+    # Combine lists with precidence ordered from most precise to least.
+    precedence_merge: "{{ [os_repo_setup['repositories'] | default([]),
+                          dist_repo_setup['repositories'] | default([]),
+                          maj_ver_repo_setup['repositories'] | default([])]
+                          | community.general.lists_mergeby('name') }}"
+  loop: "{{ lookup('ansible.builtin.vars', deps_mgr_repo_merge_method ~ '_merge') }}"
   loop_control:
     loop_var: step
   ansible.builtin.include_tasks:

--- a/roles/deps_mgr/tasks/packages.yml
+++ b/roles/deps_mgr/tasks/packages.yml
@@ -23,14 +23,22 @@
       | ansible.builtin.dict2items(key_name='name', value_name='state')
       | ansible.builtin.union(_maj_ver_packages | selectattr('name', 'defined') | list)
       }}"
+    # *Merge lists through various methods
+    # Only get repositories from the lowest-level that lists them.
+    lowest_only_merge: "{{ maj_ver_packages |
+                          default(dist_packages) |
+                          default(os_packages) |
+                          default([]) }}"
     # Combine lists with precidence ordered from most precise to least.
-    package_list: "{{
+    precedence_merge: "{{
         [os_packages | default([]), dist_packages | default([]), maj_ver_packages | default([])]
         | community.general.lists_mergeby('name')
       }}"
   ansible.builtin.package:
-    name: "{{ package_list | selectattr('state', 'equalto', state) | map(attribute='name') }}"
+    name: "{{ lookup('ansible.builtin.vars', deps_mgr_package_merge_method ~ '_merge')
+              | selectattr('state', 'equalto', state) | map(attribute='name') }}"
     state: "{{ state }}"
-  loop: "{{ package_list | map(attribute='state') | ansible.builtin.unique }}"
+  loop: "{{ lookup('ansible.builtin.vars', deps_mgr_package_merge_method ~ '_merge')
+            | map(attribute='state') | ansible.builtin.unique }}"
   loop_control:
     loop_var: state


### PR DESCRIPTION
Allows the user to specify how different levels of the `deps_mgr_list` are merged.  Includes support for the following:

| Method | Description |
| ------ | ----------- |
| lowest_only | The simplest method, it gets items from the most precise matching list and ignores all the others. |
| precision | Combine lists with precidence ordered from most precise to least. Higher-level items will be included, but can be overridden by lower level ones. |