### PR TITLE
Fix typo in merge method names.

### DIFF
--- a/changelogs/fragments/8-fix-merge-method-names.yaml
+++ b/changelogs/fragments/8-fix-merge-method-names.yaml
@@ -1,0 +1,2 @@
+doc_changes:
+  - README.md - Corrected typo that used "precision" as the name for the "precedence" method.

--- a/roles/deps_mgr/README.md
+++ b/roles/deps_mgr/README.md
@@ -36,7 +36,7 @@ If you have packages or repositories specified at multiple levels of the `deps_m
 | Method | Description |
 | ------ | ----------- |
 | lowest_only | The simplest method, it gets items from the most precise matching list and ignores all the others. |
-| precision | Combine lists with precidence ordered from most precise to least. Higher-level items will be included, but can be overridden by lower level ones. |
+| precedence | Combine lists with precidence ordered from most precise to least. Higher-level items will be included, but can be overridden by lower level ones. |
 
 
 Dependencies


### PR DESCRIPTION
"precision" is not a merge method.  The name should have been "precedence".