### PR TITLE
correct typos and clarify examples

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,21 @@ Marshallwp General Collection Release Notes
 
 .. contents:: Topics
 
+v1.3.2
+======
+
+Release Summary
+---------------
+
+Fixes documentation by removing duplicates, clarifying examples, and rectifying typos.
+
+Documentation Changes
+---------------------
+
+- docs(deps_mgr) - clarify examples and how the alpine repo_type is managed.
+- docs(java) - fix typo in vars/main.yml comments.
+- docs(java) - remove duplicate text from parameter description.
+
 v1.3.1
 ======
 

--- a/changelogs/.plugin-cache.yaml
+++ b/changelogs/.plugin-cache.yaml
@@ -25,4 +25,4 @@ plugins:
   strategy: {}
   test: {}
   vars: {}
-version: 1.3.1
+version: 1.3.2

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -104,3 +104,14 @@ releases:
     fragments:
       - 13-fix-broken-java-archive-installers.yml
     release_date: '2025-03-18'
+  1.3.2:
+    changes:
+      doc_changes:
+        - docs(deps_mgr) - clarify examples and how the alpine repo_type is managed.
+        - docs(java) - fix typo in vars/main.yml comments.
+        - docs(java) - remove duplicate text from parameter description.
+      release_summary: Fixes documentation by removing duplicates, clarifying examples,
+        and rectifying typos.
+    fragments:
+      - 14-docs-fixup.yml
+    release_date: '2025-04-16'

--- a/changelogs/fragments/14-docs-fixup.yml
+++ b/changelogs/fragments/14-docs-fixup.yml
@@ -1,6 +1,0 @@
-release_summary: Fixes documentation by removing duplicates, clarifying examples, and rectifying typos.
-
-doc_changes:
-  - docs(java): remove duplicate text from parameter description.
-  - docs(java): fix typo in vars/main.yml comments.
-  - docs(deps_mgr): clarify examples and how the alpine repo_type is managed.

--- a/changelogs/fragments/14-docs-fixup.yml
+++ b/changelogs/fragments/14-docs-fixup.yml
@@ -1,0 +1,6 @@
+release_summary: Fixes documentation by removing duplicates, clarifying examples, and rectifying typos.
+
+doc_changes:
+  - docs(java): remove duplicate text from parameter description.
+  - docs(java): fix typo in vars/main.yml comments.
+  - docs(deps_mgr): clarify examples and how the alpine repo_type is managed.

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -5,7 +5,7 @@
 
 namespace: "marshallwp"
 name: "general"
-version: 1.3.1
+version: 1.3.2
 readme: README.md
 authors:
   - William P. Marshall

--- a/roles/deps_mgr/README.md
+++ b/roles/deps_mgr/README.md
@@ -9,7 +9,7 @@ Repository management is currently only supported by the following:
 
 | repo_type | Implementing Module(s) |
 | --------- | ---------------------- |
-| alpine | [`ansible.builtin.get_url`](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/get_url_module.html), [`ansible.builtin.file`](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/file_module.html), & [`ansible.builtin.lineinfile`](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/lineinfile_module.html) |
+| alpine | [custom-implementation](tasks/repository_types/alpine.yml) using only [`ansible.builtin`](https://docs.ansible.com/ansible/latest/collections/ansible/builtin) modules |
 | apt-repo | [`community.general.apt_repo`](https://docs.ansible.com/ansible/latest/collections/community/general/apt_repo_module.html) |
 | apt | [`ansible.builtin.apt_repository`](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/apt_repository_module.html) |
 | copr | [`community.general.copr`](https://docs.ansible.com/ansible/latest/collections/community/general/copr_module.html) |
@@ -84,9 +84,11 @@ Example Playbook
 Including an example of how to use your role (for instance, with variables passed in as parameters) is always nice for users too:
 
 ```yaml
-# Example for Installing Postgres 16 with packages required for configuration via community.general.postgres.
-- name: Install Postgres 16
+# Example for Installing PostgreSQL 16 with packages required for configuration via community.general.postgres.
+- name: Install PostgreSQL 16
   hosts: servers
+  vars:
+    postgresql_version: 16
   roles:
     - role: marshallwp.general.deps_mgr
       dependencies:
@@ -135,7 +137,7 @@ Including an example of how to use your role (for instance, with variables passe
 Another way to consume this role would be:
 
 ```yaml
-- name: Install Postgres 16
+- name: Install PostgreSQL 16
   hosts: servers
   gather_facts: false
   tasks:
@@ -147,5 +149,5 @@ Another way to consume this role would be:
           Alpine:
             packages:
               - py3-psycopg
-              - "postgresql{{ postgresql_version | default(16) }}"
+              - "postgresql16"
 ```

--- a/roles/dirtree/README.md
+++ b/roles/dirtree/README.md
@@ -1,7 +1,7 @@
 marshallwp.general dirtree Role
 ========================
 
-Creates a directory tree from a dictionary of dictionaries. Lets you declare such a tree in an intuitive hierarchial manner instead of a flat list of paths.
+Creates a directory tree from a dictionary of dictionaries. Lets you declare such a tree in an intuitive hierarchical manner instead of a flat list of paths.
 
 Requirements
 ------------

--- a/roles/java/README.md
+++ b/roles/java/README.md
@@ -23,7 +23,7 @@ Role Variables
 | java_variant | Some vendors provide multiple versions of Java. This variable lets you specify which to install. | OpenJDK |
 | java_install_directory | Install directory for non-repository-based installs. | `/usr/lib/jvm/{{ java_type }}-{{ java_version }}-{{ java_vendor }}-{{ ansible_architecture }}` |
 | java_archive_download_dir | Archive download directory for non-repository-based installs. | `/tmp` |
-| java_archive_exts | When not installing from a repository, file extension will determine whether a file is installed via ansible.builtin.package or extracted via ansible.builtin.unarchive.  Files with extensions matching this list will go through the latter process. Default Java Version.  Should always be a supported version of java. | `['.bz2','.tbz','.gz','.tgz','.lz','.lzma','.tlz','.xz','.txz','.zst','.tzst']` |
+| java_archive_exts | When not installing from a repository, file extension will determine whether a file is installed via ansible.builtin.package or extracted via ansible.builtin.unarchive.  Files with extensions matching this list will go through the latter process. | `['.bz2','.tbz','.gz','.tgz','.lz','.lzma','.tlz','.xz','.txz','.zst','.tzst']` |
 
 Dependencies
 ------------

--- a/roles/java/vars/main.yml
+++ b/roles/java/vars/main.yml
@@ -1,4 +1,4 @@
-# As it turns out, '-headless' (or the abscence thereof) is nearly universal for indicating a java package is headless.
+# As it turns out, '-headless' (or the absence thereof) is nearly universal for indicating a java package is headless.
 java_headless: "{{ (java_use_headless) | ansible.builtin.ternary('-headless', '') }}"
 
 # java_packages is split by java_vendor and java_variant, before the remainder is passed as a deps_mgr_list to marshallwp.general.deps_mgr


### PR DESCRIPTION
Fixes documentation by removing duplicates, clarifying examples, and rectifying typos.