### PR TITLE
refactor(toml): split toml.py such that each filter has its own file.

### DIFF
--- a/.devcontainer/Containerfile
+++ b/.devcontainer/Containerfile
@@ -5,5 +5,5 @@
 
 FROM ghcr.io/ansible/community-ansible-dev-tools:latest
 USER root
-RUN microdnf install -y podman-compose unzip reuse && \
+RUN microdnf install -y podman-compose unzip reuse pre-commit nodejs && \
 	microdnf clean all

--- a/.devcontainer/Containerfile
+++ b/.devcontainer/Containerfile
@@ -5,5 +5,5 @@
 
 FROM ghcr.io/ansible/community-ansible-dev-tools:latest
 USER root
-RUN microdnf install -y podman-compose unzip reuse pre-commit nodejs && \
+RUN microdnf install -y glibc-langpack-en podman-compose unzip reuse pre-commit && \
 	microdnf clean all

--- a/.devcontainer/docker/devcontainer.json
+++ b/.devcontainer/docker/devcontainer.json
@@ -5,7 +5,7 @@
   },
   "containerUser": "root",
   "containerEnv": {
-    "ANSIBLE_CONFIG": "${containerWorkspaceFolder}/ansible.cfg",
+    "ANSIBLE_CONFIG": "${containerWorkspaceFolder}/ansible.cfg"
   },
   "runArgs": [
     "--security-opt", "seccomp=unconfined",
@@ -26,6 +26,10 @@
         "edwinhuish.better-comments-next"
       ]
     }
+  },
+  "postCreateCommand": {
+    "safe repo": "git config --global --add safe.directory \"${containerWorkspaceFolder}\"",
+    "pre-commit": "pre-commit install"
   },
   "postStartCommand": {
     "ansible deps": "ansible-galaxy install -r requirements.yml"

--- a/.devcontainer/podman/devcontainer.json
+++ b/.devcontainer/podman/devcontainer.json
@@ -28,6 +28,10 @@
       ]
     }
   },
+  "postCreateCommand": {
+    "safe repo": "git config --global --add safe.directory \"${containerWorkspaceFolder}\"",
+    "pre-commit": "pre-commit install"
+  },
   "postStartCommand": {
     "ansible deps": "ansible-galaxy install -r requirements.yml"
   },

--- a/.gitignore
+++ b/.gitignore
@@ -126,7 +126,7 @@ celerybeat.pid
 
 # Environments
 .env
-.venv
+.venv/
 env/
 venv/
 ENV/

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -4,7 +4,7 @@
 
 [settings]
 known_first_party=ansible_collections.marshallwp.general
-line_length=100
+line_length=180
 lines_after_imports=2
 lines_between_types=1
 profile=black

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,40 +1,46 @@
-# SPDX-FileCopyrightText: 2024 Red Hat, Inc.
+# SPDX-FileCopyrightText: 2025 Industrial Info Resources, Inc.
+# SPDX-FileContributor: William P. Marshall
 #
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 ---
 repos:
-  - repo: https://github.com/ansible-network/collection_prep
-    rev: 1.1.1
-    hooks:
-      - id: update-docs
+  # - repo: https://github.com/ansible-network/collection_prep
+  #   rev: 1.1.2
+  #   hooks:
+  #     - id: update-docs
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v6.0.0
     hooks:
+      - id: check-case-conflict
+      - id: check-illegal-windows-names
       - id: check-merge-conflict
       - id: check-symlinks
       - id: debug-statements
       - id: end-of-file-fixer
+      - id: fix-byte-order-marker
+      - id: mixed-line-ending
+        args: ['--fix=lf']
       - id: no-commit-to-branch
         args: [--branch, main]
       - id: trailing-whitespace
 
   - repo: https://github.com/asottile/add-trailing-comma
-    rev: v3.0.0
+    rev: v4.0.0
     hooks:
       - id: add-trailing-comma
 
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: "v3.0.0"
-    hooks:
-      - id: prettier
-        entry: env CI=1 bash -c "prettier --list-different . || ec=$? && prettier --loglevel=error --write . && exit $ec"
-        pass_filenames: false
-        args: []
-        additional_dependencies:
-          - prettier
-          - prettier-plugin-toml
+  # - repo: https://github.com/pre-commit/mirrors-prettier
+  #   rev: "v3.0.0"
+  #   hooks:
+  #     - id: prettier
+  #       entry: env CI=1 bash -c "prettier --list-different . || ec=$? && prettier --loglevel=error --write . && exit $ec"
+  #       pass_filenames: false
+  #       args: []
+  #       additional_dependencies:
+  #         - prettier
+  #         - prettier-plugin-toml
 
   - repo: https://github.com/PyCQA/isort
     rev: 5.12.0
@@ -44,14 +50,14 @@ repos:
         args: ["--filter-files"]
 
   - repo: https://github.com/psf/black
-    rev: 23.7.0
+    rev: 25.11.0
     hooks:
       - id: black
 
-  - repo: https://github.com/pycqa/flake8
-    rev: 7.0.0
-    hooks:
-      - id: flake8
+  # - repo: https://github.com/pycqa/flake8
+  #   rev: 7.0.0
+  #   hooks:
+  #     - id: flake8
 
 # SPDX-SnippetBegin
 # SPDX-SnippetCopyrightText: 2017 Free Software Foundation Europe e.V. <https://fsfe.org>

--- a/README.md
+++ b/README.md
@@ -7,10 +7,11 @@ SPDX-License-Identifier: GPL-3.0-or-later
 
 # Marshallwp General Collection
 
+[![Ansible Galaxy Downloads](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fgalaxy.ansible.com%2Fapi%2Fv3%2Fplugin%2Fansible%2Fcontent%2Fpublished%2Fcollections%2Findex%2Fmarshallwp%2Fgeneral%2F&query=%24.download_count&style=flat&logo=ansible&label=Galaxy%20Downloads)](https://galaxy.ansible.com/ui/repo/published/marshallwp/general/)
+
 This repository contains the `marshallwp.general` Ansible Collection.  Everything within this collection is useful in wide-ranging situations and contains minimal external dependencies.  It is intended to be extremely generic and where possible has no platform limitations.  Where platform limitations do exist (such as the `deps_mgr` role), they are made as broad as possible.
 
 <!--start requires_ansible-->
-Requires Ansible 2.15 or later
 <!--end requires_ansible-->
 
 ## External requirements

--- a/plugins/filter/from_toml.py
+++ b/plugins/filter/from_toml.py
@@ -5,6 +5,14 @@
 # SPDX-License-Identifier: MIT
 # This code is adapted from https://github.com/arillso/ansible.system/blob/42edd560716685e5fe81b3b07540610588a4bd92/plugins/filter/toml.py
 
+from __future__ import absolute_import, division, print_function
+
+import sys
+
+# pylint: disable=import-error
+from ansible.errors import AnsibleFilterError, AnsibleRuntimeError
+
+
 DOCUMENTATION = r"""
     name: from_toml
     short_description: Converts a TOML-formatted string into a Python object.
@@ -24,14 +32,6 @@ RETURN = r"""
         description: The parsed output as a dictionary
         type: dict
 """
-
-from __future__ import absolute_import, division, print_function
-
-import sys
-
-# pylint: disable=import-error
-from ansible.errors import AnsibleFilterError, AnsibleRuntimeError
-
 
 # Importing libraries for reading
 if sys.version_info >= (3, 11):

--- a/plugins/filter/from_toml.py
+++ b/plugins/filter/from_toml.py
@@ -1,0 +1,84 @@
+# SPDX-FileCopyrightText: 2025 arillso
+# SPDX-FileCopyrightText: 2025 Industrial Info Resources, Inc. <https://www.industrialinfo.com>
+# SPDX-FileContributor: William P. Marshall
+#
+# SPDX-License-Identifier: MIT
+# This code is adapted from https://github.com/arillso/ansible.system/blob/42edd560716685e5fe81b3b07540610588a4bd92/plugins/filter/toml.py
+
+DOCUMENTATION = r"""
+    name: from_toml
+    short_description: Converts a TOML-formatted string into a Python object.
+    version_added: 1.5.0
+    author: arillso
+    description:
+        - Converts a TOML string into a Python Object
+    options:
+        _input:
+            description: A TOML string
+            type: string
+            required: true
+"""
+
+RETURN = r"""
+    _value:
+        description: The parsed output as a dictionary
+        type: dict
+"""
+
+from __future__ import absolute_import, division, print_function
+
+import sys
+
+# pylint: disable=import-error
+from ansible.errors import AnsibleFilterError, AnsibleRuntimeError
+
+
+# Importing libraries for reading
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    try:
+        import tomli as tomllib
+    except ImportError as exc:
+        raise AnsibleRuntimeError(
+            'The Python library "tomli" is required for reading TOML in Python 3.10 and below.',
+        ) from exc
+
+
+def from_toml(_input):
+    """
+    Converts a TOML-formatted string into a Python object.
+
+    :param _input: The string to convert.
+    :type _input: str
+    :return: The Python object generated from the TOML string.
+    :rtype: dict
+    :raises AnsibleFilterError: If the input string is not a valid TOML string or another
+        error occurs.
+    """
+    if not isinstance(_input, str):
+        raise AnsibleFilterError(
+            f"from_toml requires a string, received: {type(_input).__name__}",
+        )
+    try:
+        return tomllib.loads(_input)
+    except Exception as e:
+        raise AnsibleFilterError(f"Error parsing TOML: {e}") from e
+
+
+# pylint: disable=R0903
+class FilterModule:
+    """
+    from_toml sonverts TOML strings to Python objects.
+    """
+
+    def filters(self):
+        """
+        Defines the filters provided by this module.
+
+        :return: A dictionary of filter names to filter functions.
+        :rtype: dict
+        """
+        return {
+            "from_toml": from_toml,
+        }

--- a/plugins/filter/to_nice_toml.py
+++ b/plugins/filter/to_nice_toml.py
@@ -5,6 +5,13 @@
 # SPDX-License-Identifier: MIT
 # This code is adapted from https://github.com/arillso/ansible.system/blob/42edd560716685e5fe81b3b07540610588a4bd92/plugins/filter/toml.py
 
+from __future__ import absolute_import, division, print_function
+
+from datetime import datetime
+
+from ansible.module_utils.common.text.converters import to_text
+
+
 DOCUMENTATION = r"""
     name: to_nice_toml
     short_description: Converts a dictionary into a nice TOML-formatted string
@@ -26,14 +33,6 @@ RETURN = r"""
         description: A TOML string
         type: string
 """
-
-from __future__ import absolute_import, division, print_function
-
-import sys
-
-from datetime import datetime
-
-from ansible.module_utils.common.text.converters import to_text
 
 
 def to_nice_toml(_input):

--- a/plugins/filter/to_nice_toml.py
+++ b/plugins/filter/to_nice_toml.py
@@ -5,131 +5,7 @@
 # SPDX-License-Identifier: MIT
 # This code is adapted from https://github.com/arillso/ansible.system/blob/42edd560716685e5fe81b3b07540610588a4bd92/plugins/filter/toml.py
 
-"""
-Ansible Filter Plugin for TOML conversion.
-
-This module provides filters for converting between TOML strings and Python objects,
-with support for Python versions before and after 3.11.
-"""
-
-from __future__ import absolute_import, division, print_function
-
-import sys
-from datetime import datetime
-
-# pylint: disable=import-error
-from ansible.errors import AnsibleFilterError, AnsibleRuntimeError
-from ansible.module_utils._text import to_text
-from ansible.module_utils.common._collections_compat import Mapping
-
-# Importing libraries for reading and writing TOML
-if sys.version_info >= (3, 11):
-    import tomllib
-else:
-    try:
-        import tomli as tomllib
-    except ImportError as exc:
-        raise AnsibleRuntimeError(
-            'The Python library "tomli" is required for reading TOML in Python 3.10 and below.'
-        ) from exc
-
-try:
-    import tomli_w as tomlw
-except ImportError as exc:
-    try:
-        # Only available on ansible-core below 2.19
-        import ansible.plugins.inventory.toml as tomlw
-    except ImportError:
-        raise AnsibleRuntimeError(
-            'The Python library "tomli-w" is required for writing TOML on ansible-core 2.19+.'
-        ) from exc
-
-
-DOCUMENTATION = r'''
-    name: from_toml
-    short_description: Converts a TOML-formatted string into a Python object.
-    version_added: 1.5.0
-    author: arillso
-    description:
-        - Converts a TOML string into a Python Object
-    options:
-        _input:
-            description: A TOML string
-            type: string
-            required: true
-'''
-
-RETURN = r'''
-    _value:
-        description: The parsed output as a dictionary
-        type: dict
-'''
-
-
-def from_toml(_input):
-    """
-    Converts a TOML-formatted string into a Python object.
-
-    :param _input: The string to convert.
-    :type _input: str
-    :return: The Python object generated from the TOML string.
-    :rtype: dict
-    :raises AnsibleFilterError: If the input string is not a valid TOML string or another
-        error occurs.
-    """
-    if not isinstance(_input, str):
-        raise AnsibleFilterError(
-            f"from_toml requires a string, received: {type(_input).__name__}"
-        )
-    try:
-        return tomllib.loads(_input)
-        # return json.dumps(python_object, default=datetime_converter)
-    except Exception as e:
-        raise AnsibleFilterError(f"Error parsing TOML: {e}") from e
-
-
-DOCUMENTATION = r'''
-    name: to_toml
-    short_description: Converts a dictionary into a TOML-formatted string
-    version_added: 1.5.0
-    author: arillso
-    description:
-        - Converts a dictionary into a TOML string
-    options:
-        _input:
-            description: A dictionary to convert into a TOML string.
-            type: dict
-            required: true
-'''
-
-RETURN = r'''
-    _value:
-        description: A TOML string
-        type: string
-'''
-
-
-def to_toml(_input):
-    """
-    Converts a Python object into a TOML-formatted string.
-
-    :param _input: The Python object to convert.
-    :type _input: Mapping
-    :return: A string in TOML format.
-    :rtype: str
-    :raises AnsibleFilterError: If the object cannot be converted or another error occurs.
-    """
-    if not isinstance(_input, Mapping):
-        raise AnsibleFilterError(
-            f"to_toml requires a dict, received: {type(_input).__name__}"
-        )
-    try:
-        return to_text(tomlw.dumps(_input), errors="surrogate_or_strict")
-    except Exception as e:
-        raise AnsibleFilterError(f"Error generating TOML: {e}") from e
-
-
-DOCUMENTATION = r'''
+DOCUMENTATION = r"""
     name: to_nice_toml
     short_description: Converts a dictionary into a nice TOML-formatted string
     version_added: 1.5.0
@@ -143,13 +19,21 @@ DOCUMENTATION = r'''
             description: A dictionary to convert into a TOML string.
             type: dict
             required: true
-'''
+"""
 
-RETURN = r'''
+RETURN = r"""
     _value:
         description: A TOML string
         type: string
-'''
+"""
+
+from __future__ import absolute_import, division, print_function
+
+import sys
+
+from datetime import datetime
+
+from ansible.module_utils.common.text.converters import to_text
 
 
 def to_nice_toml(_input):
@@ -223,18 +107,13 @@ def to_nice_toml(_input):
                 toml_str += "  " * indent + f"{key} = {format_toml_value(value)}\n"
         return toml_str
 
-    return recurse(_input)
+    return to_text(recurse(_input))
 
 
 # pylint: disable=R0903
 class FilterModule:
     """
-    Ansible Filter Module for converting between TOML and Python objects with improved formatting.
-
-    Provides three filters:
-    - from_toml: Converts TOML strings to Python objects.
-    - to_toml: Converts Python objects to TOML strings.
-    - to_nice_toml: Converts Python objects to nicely formatted TOML strings.
+    to_nice_toml converts Python objects to nicely formatted TOML strings.
     """
 
     def filters(self):
@@ -245,7 +124,5 @@ class FilterModule:
         :rtype: dict
         """
         return {
-            "to_toml": to_toml,
             "to_nice_toml": to_nice_toml,
-            "from_toml": from_toml,
         }

--- a/plugins/filter/to_toml.py
+++ b/plugins/filter/to_toml.py
@@ -1,0 +1,84 @@
+# SPDX-FileCopyrightText: 2025 arillso
+# SPDX-FileCopyrightText: 2025 Industrial Info Resources, Inc. <https://www.industrialinfo.com>
+# SPDX-FileContributor: William P. Marshall
+#
+# SPDX-License-Identifier: MIT
+# This code is adapted from https://github.com/arillso/ansible.system/blob/42edd560716685e5fe81b3b07540610588a4bd92/plugins/filter/toml.py
+
+DOCUMENTATION = r"""
+    name: to_toml
+    short_description: Converts a dictionary into a TOML-formatted string
+    version_added: 1.5.0
+    author: arillso
+    description:
+        - Converts a dictionary into a TOML string
+    options:
+        _input:
+            description: A dictionary to convert into a TOML string.
+            type: dict
+            required: true
+"""
+
+RETURN = r"""
+    _value:
+        description: A TOML string
+        type: string
+"""
+
+from __future__ import absolute_import, division, print_function
+
+import sys
+
+# pylint: disable=import-error
+from ansible.errors import AnsibleFilterError, AnsibleRuntimeError
+from ansible.module_utils.common._collections_compat import Mapping
+from ansible.module_utils.common.text.converters import to_text
+
+
+# Importing libraries for writing TOML
+try:
+    import tomli_w as tomlw
+except ImportError as exc:
+    try:
+        # Only available on ansible-core below 2.19
+        import ansible.plugins.inventory.toml as tomlw
+    except ImportError:
+        raise AnsibleRuntimeError(
+            'The Python library "tomli-w" is required for writing TOML on ansible-core 2.19+.',
+        ) from exc
+
+
+def to_toml(_input):
+    """
+    Converts a Python object into a TOML-formatted string.
+
+    :param _input: The Python object to convert.
+    :type _input: Mapping
+    :return: A string in TOML format.
+    :rtype: str
+    :raises AnsibleFilterError: If the object cannot be converted or another error occurs.
+    """
+    if not isinstance(_input, Mapping):
+        raise AnsibleFilterError(f"to_toml requires a dict, received: {type(_input).__name__}")
+    try:
+        return to_text(tomlw.dumps(_input), errors="surrogate_or_strict")
+    except Exception as e:
+        raise AnsibleFilterError(f"Error generating TOML: {e}") from e
+
+
+# pylint: disable=R0903
+class FilterModule:
+    """
+    to_toml converts Python objects to TOML strings.
+    """
+
+    def filters(self):
+        """
+        Defines the filters provided by this module.
+
+        :return: A dictionary of filter names to filter functions.
+        :rtype: dict
+        """
+        return {
+            "to_toml": to_toml,
+        }

--- a/plugins/filter/to_toml.py
+++ b/plugins/filter/to_toml.py
@@ -5,6 +5,14 @@
 # SPDX-License-Identifier: MIT
 # This code is adapted from https://github.com/arillso/ansible.system/blob/42edd560716685e5fe81b3b07540610588a4bd92/plugins/filter/toml.py
 
+from __future__ import absolute_import, division, print_function
+
+# pylint: disable=import-error
+from ansible.errors import AnsibleFilterError, AnsibleRuntimeError
+from ansible.module_utils.common._collections_compat import Mapping
+from ansible.module_utils.common.text.converters import to_text
+
+
 DOCUMENTATION = r"""
     name: to_toml
     short_description: Converts a dictionary into a TOML-formatted string
@@ -24,16 +32,6 @@ RETURN = r"""
         description: A TOML string
         type: string
 """
-
-from __future__ import absolute_import, division, print_function
-
-import sys
-
-# pylint: disable=import-error
-from ansible.errors import AnsibleFilterError, AnsibleRuntimeError
-from ansible.module_utils.common._collections_compat import Mapping
-from ansible.module_utils.common.text.converters import to_text
-
 
 # Importing libraries for writing TOML
 try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: CC-PDM-1.0
 
 [tool.black]
-line-length = 100
+line-length = 180
 
 [tool.pytest.ini_options]
 addopts = ["-vvv", "-n", "2", "--log-level", "WARNING", "--color", "yes"]

--- a/tests/unit/plugins/filter/test_from_toml.py
+++ b/tests/unit/plugins/filter/test_from_toml.py
@@ -3,12 +3,16 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from __future__ import (absolute_import, division, print_function)
+from __future__ import absolute_import, division, print_function
+
+
 __metaclass__ = type
 
-from ansible.errors import AnsibleFilterError
-from ansible_collections.marshallwp.general.plugins.filter.toml import from_toml, to_toml
 import pytest
+
+from ansible.errors import AnsibleFilterError
+
+from ansible_collections.marshallwp.general.plugins.filter.from_toml import from_toml
 
 
 # We use the @pytest.mark.parametrize decorator to parametrize the function
@@ -24,32 +28,6 @@ import pytest
     "sample, expected",
     [
         (
-            {"table": {"nested": {}, "val3": 3}, "val2": 2, "val1": 1},
-            """\
-val2 = 2
-val1 = 1
-
-[table]
-val3 = 3
-
-[table.nested]
-""",
-        )
-    ],
-)
-def test_outputs_to_toml(sample, expected):
-    assert to_toml(sample) == expected
-
-
-def test_to_toml_throws_AnsibleFilterError():
-    with pytest.raises(AnsibleFilterError):
-        to_toml('string')
-
-
-@pytest.mark.parametrize(
-    "sample, expected",
-    [
-        (
             """\
 val2 = 2
 val1 = 1
@@ -60,7 +38,7 @@ val3 = 3
 [table.nested]
 """,
             {"table": {"nested": {}, "val3": 3}, "val2": 2, "val1": 1},
-        )
+        ),
     ],
 )
 def test_outputs_from_toml(sample, expected):
@@ -69,4 +47,4 @@ def test_outputs_from_toml(sample, expected):
 
 def test_from_toml_throws_AnsibleFilterError():
     with pytest.raises(AnsibleFilterError):
-        to_toml(32)
+        from_toml(32)

--- a/tests/unit/plugins/filter/test_to_nice_toml.py
+++ b/tests/unit/plugins/filter/test_to_nice_toml.py
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: 2025 Industrial Info Resources, Inc. <https://www.industrialinfo.com>
+# SPDX-FileContributor: William P. Marshall
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+
+from __future__ import absolute_import, division, print_function
+
+
+__metaclass__ = type
+
+import pytest
+
+from ansible.errors import AnsibleFilterError
+
+from ansible_collections.marshallwp.general.plugins.filter.to_nice_toml import to_nice_toml
+
+
+# We use the @pytest.mark.parametrize decorator to parametrize the function
+# https://docs.pytest.org/en/latest/how-to/parametrize.html
+# Simply put, the first element of each tuple will be passed to
+# the test_convert_to_supported function as the test_input argument
+# and the second element of each tuple will be passed as
+# the expected argument.
+# In the function's body, we use the assert statement to check
+# if the convert_to_supported function given the test_input,
+# returns what we expect.
+@pytest.mark.parametrize(
+    "sample, expected",
+    [
+        (
+            {"table": {"nested": {}, "val3": 3}, "val2": 2, "val1": 1},
+            """\
+
+[table]
+  [table.nested]
+  val3 = 3
+val2 = 2
+val1 = 1
+""",
+        ),
+    ],
+)
+def test_outputs_to_toml(sample, expected):
+    assert to_nice_toml(sample) == expected
+
+
+# def test_to_toml_throws_AnsibleFilterError():
+#     with pytest.raises(AnsibleFilterError):
+#         to_nice_toml("string")

--- a/tests/unit/plugins/filter/test_to_nice_toml.py
+++ b/tests/unit/plugins/filter/test_to_nice_toml.py
@@ -11,9 +11,10 @@ __metaclass__ = type
 
 import pytest
 
-from ansible.errors import AnsibleFilterError
-
 from ansible_collections.marshallwp.general.plugins.filter.to_nice_toml import to_nice_toml
+
+
+# from ansible.errors import AnsibleFilterError
 
 
 # We use the @pytest.mark.parametrize decorator to parametrize the function

--- a/tests/unit/plugins/filter/test_to_toml.py
+++ b/tests/unit/plugins/filter/test_to_toml.py
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: 2025 Industrial Info Resources, Inc. <https://www.industrialinfo.com>
+# SPDX-FileContributor: William P. Marshall
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import absolute_import, division, print_function
+
+
+__metaclass__ = type
+
+import pytest
+
+from ansible.errors import AnsibleFilterError
+
+from ansible_collections.marshallwp.general.plugins.filter.to_toml import to_toml
+
+
+# We use the @pytest.mark.parametrize decorator to parametrize the function
+# https://docs.pytest.org/en/latest/how-to/parametrize.html
+# Simply put, the first element of each tuple will be passed to
+# the test_convert_to_supported function as the test_input argument
+# and the second element of each tuple will be passed as
+# the expected argument.
+# In the function's body, we use the assert statement to check
+# if the convert_to_supported function given the test_input,
+# returns what we expect.
+@pytest.mark.parametrize(
+    "sample, expected",
+    [
+        (
+            {"table": {"nested": {}, "val3": 3}, "val2": 2, "val1": 1},
+            """\
+val2 = 2
+val1 = 1
+
+[table]
+val3 = 3
+
+[table.nested]
+""",
+        ),
+    ],
+)
+def test_outputs_to_toml(sample, expected):
+    assert to_toml(sample) == expected
+
+
+def test_to_toml_throws_AnsibleFilterError():
+    with pytest.raises(AnsibleFilterError):
+        to_toml("string")

--- a/tests/unit/plugins/filter/test_to_toml.py
+++ b/tests/unit/plugins/filter/test_to_toml.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+
 from __future__ import absolute_import, division, print_function
 
 


### PR DESCRIPTION
Split up the TOML filters into separate files.  This both minimizes dependency requirements (as things like `tomli-w` are only required when you want to write TOML), and helps with testing.